### PR TITLE
BUG修改

### DIFF
--- a/20-acl_lib/include/acl_socket.h
+++ b/20-acl_lib/include/acl_socket.h
@@ -24,6 +24,78 @@
 // extern "C" {
 // #endif //extern "C"
 
+typedef enum
+{
+    E_NT_INITED = 0,
+    E_NT_CLIENT,
+    E_NT_SERVER,
+    E_NT_LISTEN,
+}ENODE_TYPE;
+
+typedef struct
+{
+	void * pPktBufMng; //接收类型socket需要一个临时缓冲，解决黏包，半包的问题，初始size为 MAX_RECV_PACKET_SIZE*2
+	u32 dwCurePBMSize; // 标记当前pPktBufMng占用空间的大小
+}TPktBufMng;
+
+typedef struct
+{
+	H_ACL_SOCKET m_hSock;
+	void * m_pContext;
+	ESELECT m_eWaitEvent;
+	FEvSelect m_pfCB;
+	u32 m_dwNodeNum;//new socket have assign a node number may be need not
+	BOOL m_bIsUsed;
+	int m_nSelectCount;
+	int m_nHBCount;
+	ENODE_TYPE m_eNodeType; //Server Node Client Node Or
+	TPktBufMng tPktBufMng; // packet buffer manager
+}TSockNode;
+
+//for store all socket node
+//select&send operation is get socket here
+
+//NODE_MAP：为防止node冲突
+//无论客户端或者服务端，都需要进行node映射
+
+//节点映射说明
+//m_nNodeMap[X]全局ID号
+//TSockNode->m_dwNodeNum 网络ID号
+
+//当为服务端时:客户端主动连接服务端，服务端分配全局ID号
+//此时网络ID号也相同，并发给客户端作为会话ID
+
+//当为客户端时:客户端收到服务端分配的网络ID作为会话ID
+//然后本地分配本地全局ID号使用
+
+//发送消息时，需要使用全局ID号
+//程序内部会对Node进行L->N操作
+//接收消息时，程序内部会对Node进行N->L操作,然后通知给用户
+//因此包在收发的时候，都有一步
+typedef struct tagSockManage
+{
+	//Node 0 is for listen
+	TSockNode * m_ptSockNodeArr;
+	//nodemap: to avode node conflict
+	u32 m_dwNodeMap[MAX_NODE_SUPPORT];//保存全局节点号->与SockNode对应
+	int m_nTotalNode;
+
+	fd_set m_fdWrite;
+	fd_set m_fdRead;
+	fd_set m_fdError;
+    //集中活动的socket位置信息，便于集合处理
+	int * pActSockPos;//Activated socket position array
+
+	H_ACL_LOCK m_hLock;
+	u32 m_dwTaskState;//
+    ETASK_STATUS m_eMainTaskStatus;
+    ETASK_STATUS m_eHBTaskStatus;
+	TACL_THREAD m_tSelectThread;
+	TACL_THREAD m_tHBThread;//heart beat thread
+	int m_nHBCount; //heart beat count
+}TSockManage;
+
+
 typedef struct tagPeerClientInfo TPeerClientInfo;
 
 //+++ begin interface

--- a/20-acl_lib/src/acl_manage.cpp
+++ b/20-acl_lib/src/acl_manage.cpp
@@ -1106,7 +1106,10 @@ s32 aclNewMsgProcess(H_ACL_SOCKET nFd, ESELECT eEvent, void* pContext)
 #ifdef WIN32
 		ACL_DEBUG(E_MOD_MSG,E_TYPE_WARNNING,"[aclNewMsgProcess] connection was forcibly closed by the remote host err id %d\n", WSAGetLastError());
 #endif
+        TSockManage * ptSockManage = (TSockManage *)getSockDataManger();
+        lockLock(ptSockManage->m_hLock);
 		aclRemoveSelectLoop(hSockmng, nFd);
+        unlockLock(ptSockManage->m_hLock);
 		return ACL_ERROR_NOERROR;
 	}
 	ACL_DEBUG(E_MOD_MSG,E_TYPE_DEBUG,"[aclNewMsgProcess] nRcvSize:%d\n",nRcvSize);
@@ -1137,7 +1140,10 @@ s32 aclNewMsgProcess(H_ACL_SOCKET nFd, ESELECT eEvent, void* pContext)
 		case WSAECONNRESET:  
 			{
 				ACL_DEBUG(E_MOD_MSG,E_TYPE_WARNNING,"[aclNewMsgProcess] connection was forcibly closed by the remote host err id %d\n", id);
-				aclRemoveSelectLoop(hSockmng, nFd);
+                TSockManage * ptSockManage = (TSockManage *)getSockDataManger();
+                lockLock(ptSockManage->m_hLock);
+                aclRemoveSelectLoop(hSockmng, nFd);
+                unlockLock(ptSockManage->m_hLock);
 				return ACL_ERROR_NOERROR;
 			}
 			break;

--- a/20-acl_lib/src/acl_socket.cpp
+++ b/20-acl_lib/src/acl_socket.cpp
@@ -27,76 +27,76 @@
 //             ---- node ------ WaitEvent
 //                          --- content 
 //                          --- RegCallBack
-typedef enum
-{
-	E_NT_INITED = 0,
-	E_NT_CLIENT,
-	E_NT_SERVER,
-	E_NT_LISTEN,
-}ENODE_TYPE;
+//typedef enum
+//{
+//    E_NT_INITED = 0,
+//    E_NT_CLIENT,
+//    E_NT_SERVER,
+//    E_NT_LISTEN,
+//}ENODE_TYPE;
 
-typedef struct
-{
-	void * pPktBufMng; //接收类型socket需要一个临时缓冲，解决黏包，半包的问题，初始size为 MAX_RECV_PACKET_SIZE*2
-	u32 dwCurePBMSize; // 标记当前pPktBufMng占用空间的大小
-}TPktBufMng;
-
-typedef struct
-{
-	H_ACL_SOCKET m_hSock;
-	void * m_pContext;
-	ESELECT m_eWaitEvent;
-	FEvSelect m_pfCB;
-	u32 m_dwNodeNum;//new socket have assign a node number may be need not
-	BOOL m_bIsUsed;
-	int m_nSelectCount;
-	int m_nHBCount;
-	ENODE_TYPE m_eNodeType; //Server Node Client Node Or
-	TPktBufMng tPktBufMng; // packet buffer manager
-}TSockNode;
-
-//for store all socket node
-//select&send operation is get socket here
-
-//NODE_MAP：为防止node冲突
-//无论客户端或者服务端，都需要进行node映射
-
-//节点映射说明
-//m_nNodeMap[X]全局ID号
-//TSockNode->m_dwNodeNum 网络ID号
-
-//当为服务端时:客户端主动连接服务端，服务端分配全局ID号
-//此时网络ID号也相同，并发给客户端作为会话ID
-
-//当为客户端时:客户端收到服务端分配的网络ID作为会话ID
-//然后本地分配本地全局ID号使用
-
-//发送消息时，需要使用全局ID号
-//程序内部会对Node进行L->N操作
-//接收消息时，程序内部会对Node进行N->L操作,然后通知给用户
-//因此包在收发的时候，都有一步
-typedef struct
-{
-	//Node 0 is for listen
-	TSockNode * m_ptSockNodeArr;
-	//nodemap: to avode node conflict
-	u32 m_dwNodeMap[MAX_NODE_SUPPORT];//保存全局节点号->与SockNode对应
-	int m_nTotalNode;
-
-	fd_set m_fdWrite;
-	fd_set m_fdRead;
-	fd_set m_fdError;
-    //集中活动的socket位置信息，便于集合处理
-	int * pActSockPos;//Activated socket position array
-
-	H_ACL_LOCK m_hLock;
-	u32 m_dwTaskState;//
-    ETASK_STATUS m_eMainTaskStatus;
-    ETASK_STATUS m_eHBTaskStatus;
-	TACL_THREAD m_tSelectThread;
-	TACL_THREAD m_tHBThread;//heart beat thread
-	int m_nHBCount; //heart beat count
-}TSockManage;
+//typedef struct
+//{
+//	void * pPktBufMng; //接收类型socket需要一个临时缓冲，解决黏包，半包的问题，初始size为 MAX_RECV_PACKET_SIZE*2
+//	u32 dwCurePBMSize; // 标记当前pPktBufMng占用空间的大小
+//}TPktBufMng;
+//
+//typedef struct
+//{
+//	H_ACL_SOCKET m_hSock;
+//	void * m_pContext;
+//	ESELECT m_eWaitEvent;
+//	FEvSelect m_pfCB;
+//	u32 m_dwNodeNum;//new socket have assign a node number may be need not
+//	BOOL m_bIsUsed;
+//	int m_nSelectCount;
+//	int m_nHBCount;
+//	ENODE_TYPE m_eNodeType; //Server Node Client Node Or
+//	TPktBufMng tPktBufMng; // packet buffer manager
+//}TSockNode;
+//
+////for store all socket node
+////select&send operation is get socket here
+//
+////NODE_MAP：为防止node冲突
+////无论客户端或者服务端，都需要进行node映射
+//
+////节点映射说明
+////m_nNodeMap[X]全局ID号
+////TSockNode->m_dwNodeNum 网络ID号
+//
+////当为服务端时:客户端主动连接服务端，服务端分配全局ID号
+////此时网络ID号也相同，并发给客户端作为会话ID
+//
+////当为客户端时:客户端收到服务端分配的网络ID作为会话ID
+////然后本地分配本地全局ID号使用
+//
+////发送消息时，需要使用全局ID号
+////程序内部会对Node进行L->N操作
+////接收消息时，程序内部会对Node进行N->L操作,然后通知给用户
+////因此包在收发的时候，都有一步
+//typedef struct tagSockManage
+//{
+//	//Node 0 is for listen
+//	TSockNode * m_ptSockNodeArr;
+//	//nodemap: to avode node conflict
+//	u32 m_dwNodeMap[MAX_NODE_SUPPORT];//保存全局节点号->与SockNode对应
+//	int m_nTotalNode;
+//
+//	fd_set m_fdWrite;
+//	fd_set m_fdRead;
+//	fd_set m_fdError;
+//    //集中活动的socket位置信息，便于集合处理
+//	int * pActSockPos;//Activated socket position array
+//
+//	H_ACL_LOCK m_hLock;
+//	u32 m_dwTaskState;//
+//    ETASK_STATUS m_eMainTaskStatus;
+//    ETASK_STATUS m_eHBTaskStatus;
+//	TACL_THREAD m_tSelectThread;
+//	TACL_THREAD m_tHBThread;//heart beat thread
+//	int m_nHBCount; //heart beat count
+//}TSockManage;
 
 //3A
 #define SELECT_3A_INTERVAL 100
@@ -1071,7 +1071,7 @@ ACL_API int aclRemoveSelectLoop(HSockManage hSockMng, H_ACL_SOCKET hSock)
 	{
 		return ACL_ERROR_INVALID;
 	}
-	lockLock(ptSockManage->m_hLock);
+	//lockLock(ptSockManage->m_hLock);
 	ptNewNode = ptSockManage->m_ptSockNodeArr;
 	for (i = 0; i < ptSockManage->m_nTotalNode; i++)
 	{
@@ -1088,7 +1088,7 @@ ACL_API int aclRemoveSelectLoop(HSockManage hSockMng, H_ACL_SOCKET hSock)
 			break;
 		}
 	}
-	unlockLock(ptSockManage->m_hLock);
+	//unlockLock(ptSockManage->m_hLock);
 	return nFindNode;
 }
 

--- a/20-acl_lib/src/acl_telnet.cpp
+++ b/20-acl_lib/src/acl_telnet.cpp
@@ -755,7 +755,10 @@ s32 newTelMsgProcess(H_ACL_SOCKET nFd, ESELECT eEvent, void* pContext)
 	if (0 == nRcvSize)//attempt to disconnect current connect
 	{
         ACL_DEBUG(E_MOD_TELNET, E_TYPE_WARNNING, "[newTelMsgProcess] telnet is disconnected\n");
+        TSockManage * ptSockManage = (TSockManage *)getSockDataManger();
+        lockLock(ptSockManage->m_hLock);
 		aclRemoveSelectLoop(getSockDataManger(), nFd);
+        unlockLock(ptSockManage->m_hLock);
 		telResetParam((HAclTel)ptAclTel);
 		return ACL_ERROR_NOERROR;
 	}
@@ -801,7 +804,10 @@ s32 newTelMsgProcess(H_ACL_SOCKET nFd, ESELECT eEvent, void* pContext)
 		if (0 == strcmp(ptAclTel->m_szCmd, "bye"))
 		{
             ACL_DEBUG(E_MOD_TELNET, E_TYPE_DEBUG, "[newTelMsgProcess] recv CMD:bye SOCK:%X\n",nFd);
+            TSockManage * ptSockManage = (TSockManage *)getSockDataManger();
+            lockLock(ptSockManage->m_hLock);
 			aclRemoveSelectLoop(getSockDataManger() ,nFd);
+            unlockLock(ptSockManage->m_hLock);
 			telResetParam((HAclTel)ptAclTel);
 			return 0;
 		}

--- a/20-acl_lib/src/version.cpp
+++ b/20-acl_lib/src/version.cpp
@@ -10,10 +10,9 @@
 //2018-07-20 zhoucc 创建
 //******************************************************************************
 #include "version.h"
-#define VER_MAIN 0 //发布版本
-#define VER_SUB1 5 //功能添加修改，优化
-#define VER_SUB2 11 //Bug修正
-
+#define VER_MAIN 0  //发布版本
+#define VER_SUB1 5  //功能添加修改，优化
+#define VER_SUB2 12 //Bug修正
 
 #define STR(s)     #s
 #define VERSION(a,b,c)  "ACL V:" STR(a) "." STR(b) "." STR(c) " " __DATE__


### PR DESCRIPTION
[liuqinji][v0.5.12]去除aclRemoveSelectLoop中上锁解锁操作，将上锁解锁操作移至调用此函数前后，以解决服务端关闭客户端连接后，客户端再次连接服务端，服务端会崩溃的问题。