### PR TITLE
 [liuqinji][v0.5.12]新增aclRemoveSelectLoopUnsafe函数，以修复因服务端关闭客户端连接后，客户端重连时，服务端崩溃的BUG。

### DIFF
--- a/20-acl_lib/include/acl_socket.h
+++ b/20-acl_lib/include/acl_socket.h
@@ -37,6 +37,7 @@ ACL_API HSockManage aclSocketManageInit(ESOCKET_MANAGE eManageType);
 ACL_API void aclSocketManageUninit(HSockManage hSockManage, ESOCKET_MANAGE eManageType);
 ACL_API int aclInsertSelectLoop(HSockManage hSockMng, H_ACL_SOCKET hSock, FEvSelect pfCB, ESELECT eSelType, int nInnerNodeID, void * pContext);
 ACL_API int aclRemoveSelectLoop(HSockManage hSockMng, H_ACL_SOCKET hSock);
+ACL_API int aclRemoveSelectLoopUnsafe(HSockManage hSockMng, H_ACL_SOCKET hSock);        //liuqj 2018.10.08 对于hSockMng，函数内部读取时不加锁
 ACL_API int aclInsertPBMAndSend(HSockManage hSockMng, H_ACL_SOCKET hSock,void * data, int nDataLen);
 
 ACL_API H_ACL_SOCKET aclCreateSocket();

--- a/20-acl_lib/src/version.cpp
+++ b/20-acl_lib/src/version.cpp
@@ -12,7 +12,7 @@
 #include "version.h"
 #define VER_MAIN 0 //发布版本
 #define VER_SUB1 5 //功能添加修改，优化
-#define VER_SUB2 11 //Bug修正
+#define VER_SUB2 12 //Bug修正
 
 
 #define STR(s)     #s


### PR DESCRIPTION
 [liuqinji][v0.5.12]新增aclRemoveSelectLoopUnsafe函数，以修复因服务端关闭客户端连接后，客户端重连时，服务端崩溃的BUG。