### PR TITLE
修复互斥锁BUG

### DIFF
--- a/20-acl_lib/include/acl_socket.h
+++ b/20-acl_lib/include/acl_socket.h
@@ -36,7 +36,9 @@ int  inet_aton(const char *cp, struct in_addr *ap);
 ACL_API HSockManage aclSocketManageInit(ESOCKET_MANAGE eManageType);
 ACL_API void aclSocketManageUninit(HSockManage hSockManage, ESOCKET_MANAGE eManageType);
 ACL_API int aclInsertSelectLoop(HSockManage hSockMng, H_ACL_SOCKET hSock, FEvSelect pfCB, ESELECT eSelType, int nInnerNodeID, void * pContext);
+ACL_API int aclInsertSelectLoopUnsafe(HSockManage hSockMng, H_ACL_SOCKET hSock, FEvSelect pfCB, ESELECT eSelType, int nInnerNodeID, void * pContext);
 ACL_API int aclRemoveSelectLoop(HSockManage hSockMng, H_ACL_SOCKET hSock);
+ACL_API int aclRemoveSelectLoopUnsafe(HSockManage hSockMng, H_ACL_SOCKET hSock);        //liuqj 2018.10.08 对于hSockMng，函数内部读取时不加锁
 ACL_API int aclInsertPBMAndSend(HSockManage hSockMng, H_ACL_SOCKET hSock,void * data, int nDataLen);
 
 ACL_API H_ACL_SOCKET aclCreateSocket();

--- a/20-acl_lib/src/acl_manage.cpp
+++ b/20-acl_lib/src/acl_manage.cpp
@@ -1106,7 +1106,7 @@ s32 aclNewMsgProcess(H_ACL_SOCKET nFd, ESELECT eEvent, void* pContext)
 #ifdef WIN32
 		ACL_DEBUG(E_MOD_MSG,E_TYPE_WARNNING,"[aclNewMsgProcess] connection was forcibly closed by the remote host err id %d\n", WSAGetLastError());
 #endif
-		aclRemoveSelectLoop(hSockmng, nFd);
+        aclRemoveSelectLoopUnsafe(hSockmng, nFd);
 		return ACL_ERROR_NOERROR;
 	}
 	ACL_DEBUG(E_MOD_MSG,E_TYPE_DEBUG,"[aclNewMsgProcess] nRcvSize:%d\n",nRcvSize);
@@ -1137,7 +1137,7 @@ s32 aclNewMsgProcess(H_ACL_SOCKET nFd, ESELECT eEvent, void* pContext)
 		case WSAECONNRESET:  
 			{
 				ACL_DEBUG(E_MOD_MSG,E_TYPE_WARNNING,"[aclNewMsgProcess] connection was forcibly closed by the remote host err id %d\n", id);
-				aclRemoveSelectLoop(hSockmng, nFd);
+                aclRemoveSelectLoopUnsafe(hSockmng, nFd);
 				return ACL_ERROR_NOERROR;
 			}
 			break;

--- a/20-acl_lib/src/acl_telnet.cpp
+++ b/20-acl_lib/src/acl_telnet.cpp
@@ -755,7 +755,7 @@ s32 newTelMsgProcess(H_ACL_SOCKET nFd, ESELECT eEvent, void* pContext)
 	if (0 == nRcvSize)//attempt to disconnect current connect
 	{
         ACL_DEBUG(E_MOD_TELNET, E_TYPE_WARNNING, "[newTelMsgProcess] telnet is disconnected\n");
-		aclRemoveSelectLoop(getSockDataManger(), nFd);
+		aclRemoveSelectLoopUnsafe(getSockDataManger(), nFd);
 		telResetParam((HAclTel)ptAclTel);
 		return ACL_ERROR_NOERROR;
 	}
@@ -801,7 +801,7 @@ s32 newTelMsgProcess(H_ACL_SOCKET nFd, ESELECT eEvent, void* pContext)
 		if (0 == strcmp(ptAclTel->m_szCmd, "bye"))
 		{
             ACL_DEBUG(E_MOD_TELNET, E_TYPE_DEBUG, "[newTelMsgProcess] recv CMD:bye SOCK:%X\n",nFd);
-			aclRemoveSelectLoop(getSockDataManger() ,nFd);
+            aclRemoveSelectLoopUnsafe(getSockDataManger() ,nFd);
 			telResetParam((HAclTel)ptAclTel);
 			return 0;
 		}
@@ -915,7 +915,7 @@ s32 newTelConnProc(H_ACL_SOCKET nFd, ESELECT eEvent, void* pContext)
 	aclECHO(hConnSock, "***==============  »¶Ó­Ê¹ÓÃACL Telnet Server  ================***\r\n");
 	aclECHO(hConnSock, "*===============================================================*\r\n");
 	aclECHO(hConnSock, ptAclTel->m_szPrompt);
-	aclInsertSelectLoop(getSockDataManger(), hConnSock, newTelMsgProcess, ESELECT_READ, -1, pContext);
+    aclInsertSelectLoopUnsafe(getSockDataManger(), hConnSock, newTelMsgProcess, ESELECT_READ, -1, pContext);
 	//	getTelnetPrompt(wConnPort);
 	ACL_DEBUG(E_MOD_TELNET, E_TYPE_DEBUG, "[newTelConnProc]  new telnet connected and Port %d\n",wConnPort);
 	aclTcpSend(hConnSock, szMarkBuf, nSendDataLen);

--- a/20-acl_lib/src/version.cpp
+++ b/20-acl_lib/src/version.cpp
@@ -12,7 +12,7 @@
 #include "version.h"
 #define VER_MAIN 0 //发布版本
 #define VER_SUB1 5 //功能添加修改，优化
-#define VER_SUB2 11 //Bug修正
+#define VER_SUB2 12 //Bug修正
 
 
 #define STR(s)     #s


### PR DESCRIPTION
[liuqinji][v0.5.12]新增aclInsertSelectLoopUnsafe和aclRemoveSelectLoopUnsafe函数，
以修复因服务端关闭客户端连接后，客户端重连时，服务端崩溃的BUG。